### PR TITLE
Modify ecs-exec to ignore AWS GuardDuty containers

### DIFF
--- a/ecs-exec
+++ b/ecs-exec
@@ -5,6 +5,7 @@
 # Written by Eric Wilbanks and Bryce Wade
 # Special thanks to Bill Kidwell (billkidwell) for fixing a myopic oversight 
 # with his addition of a profile selection feature 
+# Mark Courtade 4/11/2024 - Added Logic to ignore AWS DataGuard Containers
 
 """Drive through menus to get the command neeeded to connect to container."""
 import argparse

--- a/ecs-exec
+++ b/ecs-exec
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 
-# Version 1.1.0
-
 # Written by Eric Wilbanks and Bryce Wade
-# Special thanks to Bill Kidwell (billkidwell) for fixing a myopic oversight 
-# with his addition of a profile selection feature 
 
 """Drive through menus to get the command neeeded to connect to container."""
 import argparse
 import os
 import sys
 import boto3
+
+
 
 def get_ec2_instanceid(cluster, instanceid):
     """Look up the EC2 instance ID for a specific container instance."""
@@ -20,41 +18,6 @@ def get_ec2_instanceid(cluster, instanceid):
     # first container instance in the list
     instance_info = response['containerInstances'][0]
     return instance_info['ec2InstanceId']
-
-def identify_profile():
-    """Present a menu to select the profile."""
-    profiles = boto3.session.Session().available_profiles
-
-    if not profiles:
-        return 'default'
-    elif len(profiles) == 1:
-        return profiles[0]
-
-    profiles.sort()
-
-    profile_list = {}
-    counter = 0
-
-    for profile in profiles:
-        counter += 1
-        profile_list[counter] = profile
-
-    num_len = str(len(str(counter)))
-    template = str("{:^" + num_len + "}  {:<}")
-    print("Select the number of the profile you want to use:")
-    print(template.format('#', 'Profile'))
-    print(template.format('-' * len(num_len), '------'))
-    for key, value in profile_list.items():
-        print(template.format(key, value))
-
-    selection = int(input("\nentry: "))
-    print("Selection: ", profile_list[selection])
-
-    if selection not in profile_list.keys():
-        print("\nInvalid selection\n")
-        sys.exit(1)
-
-    return profile_list[selection]
 
 def identify_cluster():
     """Present a menu to select the cluster of interest."""
@@ -169,21 +132,23 @@ def identify_containers(ecs_cluster, target):
             # For each task add the container info for each container
             for entry in task_info['tasks']:
                 task_id = entry["taskArn"].split('/')[-1]
+                
                 if 'containerInstanceArn' in entry.keys():
                     ec2_instance_id = get_ec2_instanceid(
                         ecs_cluster, entry["containerInstanceArn"])
                 else:
                     ec2_instance_id = 'FARGATE'
                 for container in entry["containers"]:
-                    counter += 1
-                    container_info = {
-                        "name": container['name'],
-                        "task_id": task_id,
-                        "instance": ec2_instance_id,
-                        "image": container['image'],
-                        "status": container['lastStatus']
-                    }
-                    containers[counter] = container_info
+                    if "aws-guardduty-agent" not in container["name"]:
+                        counter += 1
+                        container_info = {
+                            "name": container['name'],
+                            "task_id": task_id,
+                            "instance": ec2_instance_id,
+                            "image": container['image'],
+                            "status": container['lastStatus']
+                        }
+                        containers[counter] = container_info
     return containers
 
 
@@ -266,8 +231,6 @@ def exec_to_container(cluster, task, name, shell):
     cmd = "aws ecs execute-command"
     if region_override is not None:
         cmd += " --region " + region_override;
-    if profile is not None:
-        cmd += " --profile " + profile;
     cmd += " --cluster " + cluster + " --task " + task + " --container " \
         + name + " --interactive  --command \"" + shell + "\""
     if dry_run is True:
@@ -275,21 +238,14 @@ def exec_to_container(cluster, task, name, shell):
     else:
         os.system(cmd)
 
+
 parser = argparse.ArgumentParser(
     description=('Identify a container running on AWS ECS and '
                  'then exec into it'))
-parser.add_argument(
-    '-c',
-    '--cluster',
-    type=str,
-    action="store",
-    help='Specify which ECS cluster you\'d like to use')
-parser.add_argument(
-    '-s',
-    '--service',
-    type=str,
-    action="store",
-    help='Specify which ECS service you\'d like to use')
+parser.add_argument('-c', '--cluster', type=str, action="store",
+                    help='Specify which ECS cluster you\'d like to use')
+parser.add_argument('-s', '--service', type=str, action="store",
+                    help='Specify which ECS service you\'d like to use')
 parser.add_argument(
     '-S',
     '--shell',
@@ -309,25 +265,12 @@ parser.add_argument(
     help=('Provide a different AWS region than what\'s specfied '
           'in your AWS_Region env var'))
 parser.add_argument(
-    '-P',
-    '--profile',
-    type=str,
-    action='store',
-    help=('Specify which AWS profile you would like to use'))
-parser.add_argument(
-    '-p',
-    '--select_profile',
-    action='store_true',
-    default=False,
-    help=('Select from a list which AWS profile you would like to use'))
-parser.add_argument(
     '-d',
     '--dry',
     action='store_true',
     default=False,
     help=('Dry run: provide the command to run instead of '
           'actually executing it'))
-
 args = vars(parser.parse_args())
 
 target_cluster = args['cluster']
@@ -335,21 +278,8 @@ target_service = args['service']
 shell_override = args['shell']
 region_override = args['region']
 dry_run = args['dry']
-profile_override = args['profile']
 
-if args['select_profile'] is True:
-    profile = identify_profile()
-elif profile_override is not None:
-    profile = profile_override
-else:
-    profile = None
-
-if profile is not None:
-    session = boto3.session.Session(region_name=args['region'], profile_name=profile)
-    client = session.client('ecs')
-else:
-    client = boto3.client('ecs', region_name=args['region'])
-
+client = boto3.client('ecs', region_name=args['region'])
 if target_cluster is None:
     target_cluster = identify_cluster()
 if target_service is None:

--- a/ecs-exec
+++ b/ecs-exec
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 
+# Version 1.1.0
+
 # Written by Eric Wilbanks and Bryce Wade
+# Special thanks to Bill Kidwell (billkidwell) for fixing a myopic oversight 
+# with his addition of a profile selection feature 
 
 """Drive through menus to get the command neeeded to connect to container."""
 import argparse
 import os
 import sys
 import boto3
-
-
 
 def get_ec2_instanceid(cluster, instanceid):
     """Look up the EC2 instance ID for a specific container instance."""
@@ -18,6 +20,41 @@ def get_ec2_instanceid(cluster, instanceid):
     # first container instance in the list
     instance_info = response['containerInstances'][0]
     return instance_info['ec2InstanceId']
+
+def identify_profile():
+    """Present a menu to select the profile."""
+    profiles = boto3.session.Session().available_profiles
+
+    if not profiles:
+        return 'default'
+    elif len(profiles) == 1:
+        return profiles[0]
+
+    profiles.sort()
+
+    profile_list = {}
+    counter = 0
+
+    for profile in profiles:
+        counter += 1
+        profile_list[counter] = profile
+
+    num_len = str(len(str(counter)))
+    template = str("{:^" + num_len + "}  {:<}")
+    print("Select the number of the profile you want to use:")
+    print(template.format('#', 'Profile'))
+    print(template.format('-' * len(num_len), '------'))
+    for key, value in profile_list.items():
+        print(template.format(key, value))
+
+    selection = int(input("\nentry: "))
+    print("Selection: ", profile_list[selection])
+
+    if selection not in profile_list.keys():
+        print("\nInvalid selection\n")
+        sys.exit(1)
+
+    return profile_list[selection]
 
 def identify_cluster():
     """Present a menu to select the cluster of interest."""
@@ -231,6 +268,8 @@ def exec_to_container(cluster, task, name, shell):
     cmd = "aws ecs execute-command"
     if region_override is not None:
         cmd += " --region " + region_override;
+    if profile is not None:
+        cmd += " --profile " + profile;
     cmd += " --cluster " + cluster + " --task " + task + " --container " \
         + name + " --interactive  --command \"" + shell + "\""
     if dry_run is True:
@@ -238,14 +277,21 @@ def exec_to_container(cluster, task, name, shell):
     else:
         os.system(cmd)
 
-
 parser = argparse.ArgumentParser(
     description=('Identify a container running on AWS ECS and '
                  'then exec into it'))
-parser.add_argument('-c', '--cluster', type=str, action="store",
-                    help='Specify which ECS cluster you\'d like to use')
-parser.add_argument('-s', '--service', type=str, action="store",
-                    help='Specify which ECS service you\'d like to use')
+parser.add_argument(
+    '-c',
+    '--cluster',
+    type=str,
+    action="store",
+    help='Specify which ECS cluster you\'d like to use')
+parser.add_argument(
+    '-s',
+    '--service',
+    type=str,
+    action="store",
+    help='Specify which ECS service you\'d like to use')
 parser.add_argument(
     '-S',
     '--shell',
@@ -265,12 +311,25 @@ parser.add_argument(
     help=('Provide a different AWS region than what\'s specfied '
           'in your AWS_Region env var'))
 parser.add_argument(
+    '-P',
+    '--profile',
+    type=str,
+    action='store',
+    help=('Specify which AWS profile you would like to use'))
+parser.add_argument(
+    '-p',
+    '--select_profile',
+    action='store_true',
+    default=False,
+    help=('Select from a list which AWS profile you would like to use'))
+parser.add_argument(
     '-d',
     '--dry',
     action='store_true',
     default=False,
     help=('Dry run: provide the command to run instead of '
           'actually executing it'))
+
 args = vars(parser.parse_args())
 
 target_cluster = args['cluster']
@@ -278,8 +337,21 @@ target_service = args['service']
 shell_override = args['shell']
 region_override = args['region']
 dry_run = args['dry']
+profile_override = args['profile']
 
-client = boto3.client('ecs', region_name=args['region'])
+if args['select_profile'] is True:
+    profile = identify_profile()
+elif profile_override is not None:
+    profile = profile_override
+else:
+    profile = None
+
+if profile is not None:
+    session = boto3.session.Session(region_name=args['region'], profile_name=profile)
+    client = session.client('ecs')
+else:
+    client = boto3.client('ecs', region_name=args['region'])
+
 if target_cluster is None:
     target_cluster = identify_cluster()
 if target_service is None:

--- a/ecs-exec
+++ b/ecs-exec
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Version 1.1.0
+# Version 1.1.1
 
 # Written by Eric Wilbanks and Bryce Wade
 # Special thanks to Bill Kidwell (billkidwell) for fixing a myopic oversight 


### PR DESCRIPTION
Addresses a bug when AWS GuardDuty is enabled which GuardDuty containers do not contain image name. 